### PR TITLE
Refactored the test scripts according to the POM

### DIFF
--- a/tests/test_login_page.py
+++ b/tests/test_login_page.py
@@ -1,20 +1,10 @@
-from playwright.sync_api import expect
 from utils.env_reader import get_url
+from page_object_models.login import Login
 
 
 def test_login_page_elements(open_page):
-    page = open_page
-    expect(page).to_have_url(get_url())
-    expect(page.locator("[data-test=\"username\"]")).to_be_visible()
-    expect(page.locator("[data-test=\"password\"]")).to_be_visible()
-    expect(page.locator("[data-test=\"login-button\"]")).to_be_visible()
+    Login(open_page).has_url(get_url()).check_page_elements()
 
 def test_login_functionality(open_page):
-    page = open_page
-    page.locator("[data-test=\"username\"]").click()
-    page.locator("[data-test=\"username\"]").fill("standard_user")
-    page.locator("[data-test=\"password\"]").click()
-    page.locator("[data-test=\"password\"]").fill("secret_sauce")
-    page.locator("[data-test=\"login-button\"]").click()
-    expect(page.locator("[data-test=\"primary-header\"] div").filter(
-        has_text="Swag Labs").first).to_be_visible()
+    Login(open_page).login("standard_user",
+                           "secret_sauce").check_login_success()


### PR DESCRIPTION
## What’s done
Refactored the test scripts to reflect the chainable POM.

## Why
To improve readability, maintainability, flexibility, and ease of future changes.

## Changes
The test scripts are now shorter and more readable.

## How to test
`pytest`